### PR TITLE
Replace async channel logging with sync mutex implementation

### DIFF
--- a/examples/json_to_file/main.go
+++ b/examples/json_to_file/main.go
@@ -18,7 +18,6 @@ func main() {
 
 	// Create new logger instance
 	log := logger.New(logger.DEBUG, file, true)
-	defer log.Close()
 
 	// Imitation of logging from multiple goroutines
 	go func() {

--- a/examples/json_to_stdout/main.go
+++ b/examples/json_to_stdout/main.go
@@ -10,7 +10,6 @@ import (
 func main() {
 	// Create new logger instance
 	log := logger.New(logger.DEBUG, os.Stdout, true)
-	defer log.Close()
 
 	// Imitation of logging from multiple goroutines
 	go func() {
@@ -25,6 +24,9 @@ func main() {
 			time.Sleep(200 * time.Millisecond)
 
 			log.Error(fmt.Sprintf("Goroutine 1 – %s message %d", logger.GetLevelString(logger.ERROR), i))
+			time.Sleep(200 * time.Millisecond)
+
+			log.Fatal(fmt.Sprintf("Goroutine 1 – %s message %d", logger.GetLevelString(logger.FATAL), i))
 			time.Sleep(200 * time.Millisecond)
 		}
 	}()

--- a/examples/text_to_stdout/main.go
+++ b/examples/text_to_stdout/main.go
@@ -10,7 +10,6 @@ import (
 func main() {
 	// Create new logger instance
 	log := logger.New(logger.DEBUG, os.Stdout, false)
-	defer log.Close()
 
 	// Imitation of logging from multiple goroutines
 	go func() {

--- a/logger.go
+++ b/logger.go
@@ -103,10 +103,6 @@ func (l *Logger) Log(level int, message string) {
 		Time:  time.Now(),
 	}
 
-	// Creates and writes a log message with thread-safe synchronization
-	l.mu.Lock()
-	defer l.mu.Unlock()
-
 	var logRecord string
 	var err error
 
@@ -120,6 +116,10 @@ func (l *Logger) Log(level int, message string) {
 	} else {
 		logRecord = l.formatText(logMessage)
 	}
+
+	// Creates and writes a log message with thread-safe synchronization
+	l.mu.Lock()
+	defer l.mu.Unlock()
 
 	// Write the formatted log message to the specified output writer
 	if _, err = fmt.Fprint(l.writer, logRecord); err != nil {


### PR DESCRIPTION
## Brief
Replaced asynchronous logging through channels with synchronous mutex-based implementation to provide thread-safe logging with guaranteed message delivery.

## Changes
- Removed message buffering channels (`logChan`, `done`)
- Added `sync.Mutex` for thread-safe log writing
- Removed goroutine-based message processing (`run()` method)
- Made `Fatal` level logging synchronous with immediate program termination